### PR TITLE
@mk/generate update

### DIFF
--- a/factory-cli/data/recipes/recipes.json
+++ b/factory-cli/data/recipes/recipes.json
@@ -16,7 +16,8 @@
           "name": "sample-database",
           "environment": "node",
           "template": "node-shaman-database",
-          "path": "database"
+          "path": "database",
+          "specs": {}
         },
         {
           "name": "sample-library",
@@ -53,7 +54,8 @@
           "name": "sample-database",
           "environment": "node",
           "template": "node-shaman-database",
-          "path": "database"
+          "path": "database",
+          "specs": {}
         },
         {
           "name": "sample-server",

--- a/factory-cli/src/commands/generate/generate.command.prompts.spec.ts
+++ b/factory-cli/src/commands/generate/generate.command.prompts.spec.ts
@@ -86,6 +86,115 @@ describe('Generate Command Prompts', () => {
         });
     });
 
+    it('askToRenameDataContext should return a new recipe with renamed data context', (done) => {
+        let subject = new GenerateCommandPrompts;
+        let interactionMock = createMock<InteractiveCommands>();
+        interactionMock.interrogate = sandbox.stub().returns(Promise.resolve({
+            'test-database': 'TestDataContext'
+        }));
+        subject.interaction = interactionMock;
+        let testRecipe: Recipe = {
+            name: 'test-recipe',
+            projects: [{
+                name: 'test-database',
+                environment: 'node',
+                template: 'database',
+                path: 'database',
+                specs: {}
+            }]
+        };
+        let expected: Recipe = {
+            name: 'test-recipe',
+            projects: [{
+                name: 'test-database',
+                environment: 'node',
+                template: 'database',
+                path: 'database',
+                specs: {
+                    'contextName': 'TestDataContext'
+                }
+            }]
+        };
+        subject.askToRenameDataContext(testRecipe)
+            .then(actual => {
+                assert.deepEqual(actual, expected);
+                done();
+            })
+            .catch(err => done(new Error(err)));
+    });
+
+    it('askToRenameDataContext should return the input recipe if no database projects are found', (done) => {
+        let subject = new GenerateCommandPrompts;
+        let testRecipe: Recipe = {
+            name: 'test-recipe',
+            projects: [{
+                name: 'test-server',
+                environment: 'node',
+                template: 'server',
+                path: 'server'
+            }]
+        };
+        let expected: Recipe = { ...testRecipe };
+        subject.askToRenameDataContext(testRecipe)
+            .then(actual => {
+                assert.deepEqual(actual, expected);
+                done();
+            })
+            .catch(err => done(new Error(err)));
+    });
+
+    it('askToRenameDataContext should return the input recipe if an empty string is passed as the context name', (done) => {
+        let subject = new GenerateCommandPrompts;
+        let interactionMock = createMock<InteractiveCommands>();
+        interactionMock.interrogate = sandbox.stub().returns(Promise.resolve({
+            'test-database': ''
+        }));
+        subject.interaction = interactionMock;
+        let testRecipe: Recipe = {
+            name: 'test-recipe',
+            projects: [{
+                name: 'test-database',
+                environment: 'node',
+                template: 'database',
+                path: 'database',
+                specs: {}
+            }]
+        };
+        let expected: Recipe = { ...testRecipe };
+        subject.askToRenameDataContext(testRecipe)
+            .then(actual => {
+                assert.deepEqual(actual, expected);
+                done();
+            })
+            .catch(err => done(new Error(err)));
+    });
+
+    it('askToRenameDataContext should return the input recipe if an empty string is passed as the context name', (done) => {
+        let subject = new GenerateCommandPrompts;
+        let interactionMock = createMock<InteractiveCommands>();
+        interactionMock.interrogate = sandbox.stub().returns(Promise.resolve({
+            'test-database': ''
+        }));
+        subject.interaction = interactionMock;
+        let testRecipe: Recipe = {
+            name: 'test-recipe',
+            projects: [{
+                name: 'test-database',
+                environment: 'node',
+                template: 'database',
+                path: 'database',
+                specs: {}
+            }]
+        };
+        let expected: Recipe = { ...testRecipe };
+        subject.askToRenameDataContext(testRecipe)
+            .then(actual => {
+                assert.deepEqual(actual, expected);
+                done();
+            })
+            .catch(err => done(new Error(err)));
+    });
+
     it('askForTemplateName should return value for template key', (done) => {
         let subject = new GenerateCommandPrompts();
         let interactionMock = createMock<InteractiveCommands>();

--- a/factory-cli/src/commands/generate/generate.command.spec.ts
+++ b/factory-cli/src/commands/generate/generate.command.spec.ts
@@ -195,7 +195,7 @@ describe('Generate Command', () => {
         subject.run(cla).then(_ => done());
     });
 
-    it('run should transformations in shaman.json if the selected recipe includes transformations', (done) => {
+    it('run should perform transformations in shaman.json if the selected recipe includes transformations', (done) => {
         let subject = new GenerateCommand();
         let cla = new CommandLineArguments(['', '', 'generate']);
         let fileServiceMock = createMock<IFileService>();
@@ -219,7 +219,29 @@ describe('Generate Command', () => {
                 name: "renamed-sample-database",
                 environment: "node",
                 type: "database",
-                path: "database"
+                path: "database",
+                specs: { }
+            }],
+            transform: [
+                {
+                    targetProject: "renamed-sample-server",
+                    transformation: "compose:datacontext",
+                    sourceProject: "renamed-sample-database"
+                }
+            ]
+        }));
+        promptsMock.askToRenameDataContext = sandbox.stub().returns(Promise.resolve({
+            projects: [{
+                name: "renamed-sample-server",
+                environment: "node",
+                type: "server",
+                path: "server"
+            }, {
+                name: "renamed-sample-database",
+                environment: "node",
+                type: "database",
+                path: "database",
+                specs: { contextName: "SampleDataContext" }
             }],
             transform: [
                 {

--- a/factory-cli/src/commands/generate/generate.command.ts
+++ b/factory-cli/src/commands/generate/generate.command.ts
@@ -69,6 +69,7 @@ export class GenerateCommand implements ICommand {
             })
             .then(_ => this.recipeService.getRecipe(this.args.recipeName))
             .then(recipe => this.prompts.askToRenameRecipeProjects(recipe))
+            .then(recipe => this.prompts.askToRenameDataContext(recipe))
             .then(updatedRecipe => this.generateShamanFile(updatedRecipe.projects, updatedRecipe.transform))
     }
 

--- a/factory-cli/src/services/source/csharp-source.service.spec.ts
+++ b/factory-cli/src/services/source/csharp-source.service.spec.ts
@@ -10,7 +10,7 @@ import { SolutionProject } from '../../models/solution';
 import { LineDetail, SourceFile } from '../../models/source-file';
 import { ISourceFactory } from '../../factories/source/source.factory';
 
-describe('Typescript Source Service', () => {
+describe('Csharp Source Service', () => {
   
   chai.use(sinonChai);
   var sandbox: sinon.SinonSandbox;

--- a/factory-cli/src/services/source/typescript-source.service.spec.ts
+++ b/factory-cli/src/services/source/typescript-source.service.spec.ts
@@ -11,7 +11,7 @@ import { LineDetail, SourceFile } from '../../models/source-file';
 import { ISourceFactory } from '../../factories/source/source.factory';
 
 describe('Typescript Source Service', () => {
-  
+
   chai.use(sinonChai);
   var sandbox: sinon.SinonSandbox;
   const importHook = `//shaman: {"lifecycle": "transformation", "args": {"type": "import", "target": "*"}}`;
@@ -28,6 +28,23 @@ describe('Typescript Source Service', () => {
     sandbox.restore();
   });
 
+  it('should copy app.config.sample.json to app.config.json', (done) => {
+    let project = new SolutionProject();
+    project.path = "sample"
+    let fileServiceMock = createMock<IFileService>();
+    fileServiceMock.copyFile = sandbox.stub().returns(Promise.resolve());
+    let subject = new TypescriptSourceService();
+    subject.fileService = fileServiceMock;
+    subject.createAppConfigFromSampleConfig("./", project).then(_ => {
+      expect(fileServiceMock.copyFile).to.have.been.calledOnceWith(
+        "sample\\app\\config\\app.config.sample.json",
+        "sample\\app\\config\\app.config.json"
+      );
+      done();
+    })
+      .catch(ex => done(new Error(ex)));
+  });
+  
   it('addMySqlAppConfigurationJson should update 2 json files', (done) => {
     let project = new SolutionProject();
     project.path = "./sample"
@@ -62,7 +79,7 @@ describe('Typescript Source Service', () => {
     let project = new SolutionProject();
     project.path = "./sample"
     let sourceFile = new SourceFile();
-    sourceFile.lines = [new LineDetail({index: 0, indent: 0, content: importHook, lifecycleHook: true})]
+    sourceFile.lines = [new LineDetail({ index: 0, indent: 0, content: importHook, lifecycleHook: true })]
     let fileServiceMock = createMock<IFileService>();
     fileServiceMock.getSourceFile = sandbox.stub().returns(Promise.resolve(sourceFile));
     let subject = new TypescriptSourceService();
@@ -80,8 +97,8 @@ describe('Typescript Source Service', () => {
     project.path = "./sample"
     let sourceFile = new SourceFile();
     sourceFile.lines = [
-      new LineDetail({index: 0, indent: 0, content: importHook, lifecycleHook: true}),
-      new LineDetail({index: 1, indent: 0, content: configurationHook, lifecycleHook: true})
+      new LineDetail({ index: 0, indent: 0, content: importHook, lifecycleHook: true }),
+      new LineDetail({ index: 1, indent: 0, content: configurationHook, lifecycleHook: true })
     ]
     sandbox.stub(sourceFile, 'replaceLines').callsFake((_i, lineFactory) => lineFactory());
     let fileServiceMock = createMock<IFileService>();
@@ -119,7 +136,7 @@ describe('Typescript Source Service', () => {
     project.path = "./sample"
     let sourceFile = new SourceFile();
     sourceFile.lines = [
-      new LineDetail({index: 0, indent: 0, content: compositionTypesHook, lifecycleHook: true})
+      new LineDetail({ index: 0, indent: 0, content: compositionTypesHook, lifecycleHook: true })
     ]
     sandbox.stub(sourceFile, 'replaceLines').callsFake((_i, lineFactory) => lineFactory());
     let fileServiceMock = createMock<IFileService>();
@@ -155,7 +172,7 @@ describe('Typescript Source Service', () => {
     let project = new SolutionProject();
     project.path = "./sample"
     let sourceFile = new SourceFile();
-    sourceFile.lines = [new LineDetail({index: 0, indent: 0, content: importHook, lifecycleHook: true})]
+    sourceFile.lines = [new LineDetail({ index: 0, indent: 0, content: importHook, lifecycleHook: true })]
     let fileServiceMock = createMock<IFileService>();
     fileServiceMock.getSourceFile = sandbox.stub().returns(Promise.resolve(sourceFile));
     let subject = new TypescriptSourceService();
@@ -173,8 +190,8 @@ describe('Typescript Source Service', () => {
     project.path = "./sample"
     let sourceFile = new SourceFile();
     sourceFile.lines = [
-      new LineDetail({index: 0, indent: 0, content: importHook, lifecycleHook: true}),
-      new LineDetail({index: 1, indent: 0, content: compositionHook, lifecycleHook: true})
+      new LineDetail({ index: 0, indent: 0, content: importHook, lifecycleHook: true }),
+      new LineDetail({ index: 1, indent: 0, content: compositionHook, lifecycleHook: true })
     ]
     sandbox.stub(sourceFile, 'replaceLines').callsFake((_i, lineFactory) => lineFactory());
     let fileServiceMock = createMock<IFileService>();

--- a/factory-cli/src/services/source/typescript-source.service.ts
+++ b/factory-cli/src/services/source/typescript-source.service.ts
@@ -5,10 +5,11 @@ import { SolutionProject } from "../../models/solution";
 import { FileService, IFileService } from '../file.service';
 
 export interface ITypescriptSourceService {
+  createAppConfigFromSampleConfig: (solutionFolderPath: string, project: SolutionProject) => Promise<void>;
   addMySqlAppConfigurationJson: (solutionFolderPath: string, project: SolutionProject) => Promise<void>;
   addMySqlAppConfigurationModel: (solutionFolderPath: string, project: SolutionProject) => Promise<void>;
   addDataContextCompositionType: (solutionFolderPath: string, project: SolutionProject, contextName: string) => Promise<void>;
-  addDataContextComposition: (solutionFolderPath: string, project: SolutionProject, 
+  addDataContextComposition: (solutionFolderPath: string, project: SolutionProject,
     databaseProjectName: string, contextName: string) => Promise<void>;
 }
 
@@ -16,6 +17,13 @@ export class TypescriptSourceService implements ITypescriptSourceService {
 
   fileService: IFileService = new FileService();
   sourceFactory: ISourceFactory = new TypescriptSourceFactory();
+
+  createAppConfigFromSampleConfig = (solutionFolderPath: string, project: SolutionProject): Promise<void> => {
+    const projectFolderPath = _path.join(solutionFolderPath, project.path);
+    const configFilePath = _path.join(projectFolderPath, 'app', 'config', 'app.config.json');
+    const sampleConfigFilePath = _path.join(projectFolderPath, 'app', 'config', 'app.config.sample.json');
+    return this.fileService.copyFile(sampleConfigFilePath, configFilePath);
+  }
 
   addMySqlAppConfigurationJson = (solutionFolderPath: string, project: SolutionProject): Promise<void> => {
     const projectFolderPath = _path.join(solutionFolderPath, project.path);
@@ -59,7 +67,7 @@ export class TypescriptSourceService implements ITypescriptSourceService {
       return this.fileService.writeFile(configFilePath, sourceFile.toString());
     });
   }
-  
+
   addDataContextCompositionType = (solutionFolderPath: string, project: SolutionProject, contextName: string): Promise<void> => {
     const projectFolderPath = _path.join(solutionFolderPath, project.path);
     const typesFilePath = _path.join(projectFolderPath, 'src', 'composition', 'app.composition.types.ts');
@@ -76,7 +84,7 @@ export class TypescriptSourceService implements ITypescriptSourceService {
     });
   }
 
-  addDataContextComposition = (solutionFolderPath: string, project: SolutionProject, 
+  addDataContextComposition = (solutionFolderPath: string, project: SolutionProject,
     databaseProjectName: string, contextName: string): Promise<void> => {
     const projectFolderPath = _path.join(solutionFolderPath, project.path);
     const compositionFilePath = _path.join(projectFolderPath, 'src', 'composition', 'app.composition.ts');

--- a/factory-cli/src/transformations/node/node-compose-datacontext.transform.ts
+++ b/factory-cli/src/transformations/node/node-compose-datacontext.transform.ts
@@ -17,7 +17,8 @@ export class NodeComposeDataContextTransformation implements ITransformation {
     let databaseProject = solution.projects.find(p => p.name == transformation.sourceProject);
     if (!databaseProject) return Promise.reject(new Error(`Invalid source project in transformation: '${transformation.sourceProject}'.`));
     const contextName = databaseProject.specs?.contextName ?? "SampleDatabaseContext";
-    return this.sourceService.addMySqlAppConfigurationJson(solutionFolderPath, project)
+    return this.sourceService.createAppConfigFromSampleConfig(solutionFolderPath, project)
+      .then(_ => this.sourceService.addMySqlAppConfigurationJson(solutionFolderPath, project))
       .then(_ => this.sourceService.addMySqlAppConfigurationModel(solutionFolderPath, project))
       .then(_ => this.sourceService.addDataContextCompositionType(solutionFolderPath, project, contextName))
       .then(_ => this.sourceService.addDataContextComposition(solutionFolderPath, project, databaseProject.name, contextName));


### PR DESCRIPTION
- adding method to create app.config.json from app.config.sample.json during dataContext transformation
- adding interrogation method which allows for users to rename the dataContext for recipes that include a database project.